### PR TITLE
fix: 修复用户中心上传的头像路径出现重复斜杠 #18

### DIFF
--- a/beike/Shop/Http/Controllers/FileController.php
+++ b/beike/Shop/Http/Controllers/FileController.php
@@ -8,10 +8,15 @@ class FileController extends Controller
 {
     public function store(UploadRequest $request)
     {
+        $request->validate([
+            "file" => "required|file",
+            "type" => "required|alpha_dash",
+        ]);
+
         $file = $request->file('file');
         $type = $request->get('type');
 
-        $path = $file->store($type . '/', 'upload');
+        $path = $file->store($type, 'upload');
 
         $data = [
             'url'   => asset('upload/' . $path),


### PR DESCRIPTION
- 控制器增加参数校验
- 文件夹路径去除多余`/`