### PR TITLE
插件配置增加默认的图像编辑方式

### DIFF
--- a/resources/beike/admin/views/pages/plugins/form.blade.php
+++ b/resources/beike/admin/views/pages/plugins/form.blade.php
@@ -17,6 +17,18 @@
           {{ method_field('put') }}
 
           @foreach ($plugin->getColumns() as $column)
+            @if ($column['type'] == 'image')
+              <x-admin-form-image
+                :name="$column['name']"
+                :title="$column['label']"
+                :placeholder="$column['placeholder'] ?? ''"
+                :description="$column['description'] ?? ''"
+                :error="$errors->first($column['name'])"
+                :required="$column['required'] ? true : false"
+                :value="old($column['name'], $column['value'] ?? '')">
+                <div class="help-text font-size-12 lh-base">{{ __('common.recommend_size') }} {{ $column['recommend_size'] ?? '100*100' }}</div>
+              </x-admin-form-image>
+            @endif
             @if ($column['type'] == 'string')
               <x-admin-form-input
                 :name="$column['name']"


### PR DESCRIPTION
很多插件配置需要配置图标或者其他图片文件
增加一个默认的，省去各个开发在插件里面需要去自己写这个图像的更改配置
增加代码如下:
@if ($column['type'] == 'image')
              <x-admin-form-image
                :name="$column['name']"
                :title="$column['label']"
                :placeholder="$column['placeholder'] ?? ''"
                :description="$column['description'] ?? ''"
                :error="$errors->first($column['name'])"
                :required="$column['required'] ? true : false"
                :value="old($column['name'], $column['value'] ?? '')">
                <div class="help-text font-size-12 lh-base">{{ __('common.recommend_size') }} {{ $column['recommend_size'] ?? '100*100' }}</div>
              </x-admin-form-image>
            @endif