### PR TITLE
Add PayPal NVP/SOAP API support

### DIFF
--- a/plugins/Paypal/Controllers/PaypalController.php
+++ b/plugins/Paypal/Controllers/PaypalController.php
@@ -19,24 +19,26 @@ use Beike\Repositories\OrderPaymentRepo;
 use Beike\Repositories\OrderRepo;
 use Beike\Services\StateMachineService;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
 use Plugin\Paypal\Services\PaypalService;
-use Srmklive\PayPal\Services\PayPal;
 
 class PaypalController
 {
-    private PayPal $paypalClient;
+    private ?PaypalService $paypalService = null;
 
     /**
      * Init Paypal
      *
      * @throws \Throwable
      */
-    private function initPaypal($order): void
+    private function initPaypal($order): PaypalService
     {
-        $paypalService      = new PaypalService($order);
-        $this->paypalClient = $paypalService->paypalClient;
+        $this->paypalService = new PaypalService($order);
+
+        return $this->paypalService;
     }
 
     /**
@@ -47,23 +49,22 @@ class PaypalController
      */
     public function create(Request $request): JsonResponse
     {
-        $data        = \json_decode($request->getContent(), true);
-        $orderNumber = $data['orderNumber'];
-        $customer    = current_customer();
-        $order       = OrderRepo::getOrderByNumber($orderNumber, $customer);
-        $this->initPaypal($order);
-        $paypalOrder = $this->paypalClient->createOrder([
-            'intent'         => 'CAPTURE',
-            'purchase_units' => [
-                [
-                    'amount'      => [
-                        'currency_code' => system_setting('base.currency'),
-                        'value'         => round($order->total, 2),
-                    ],
-                    'description' => $order->getOrderDesc(128),
-                ],
-            ],
-        ]);
+        $data        = $this->getRequestData($request);
+        $orderNumber = $this->getOrderNumberFromData($data, $request);
+
+        if ($orderNumber === '') {
+            return response()->json(['message' => 'orderNumber is required'], 422);
+        }
+
+        $customer      = current_customer();
+        $order         = OrderRepo::getOrderByNumber($orderNumber, $customer);
+        $paypalService = $this->initPaypal($order);
+
+        if ($paypalService->isNvpApi()) {
+            $paypalOrder = $paypalService->createNvpOrder($this->getNvpCheckoutUrls($request, $orderNumber, $data));
+        } else {
+            $paypalOrder = $paypalService->createOrder();
+        }
 
         return response()->json($paypalOrder);
     }
@@ -76,28 +77,188 @@ class PaypalController
      */
     public function capture(Request $request): JsonResponse
     {
-        $data        = \json_decode($request->getContent(), true);
-        $orderNumber = $data['orderNumber'];
-        $customer    = current_customer();
-        $order       = OrderRepo::getOrderByNumber($orderNumber, $customer);
+        $data        = $this->getRequestData($request);
+        $orderNumber = $this->getOrderNumberFromData($data, $request);
 
-        $this->initPaypal($order);
-        OrderPaymentRepo::createOrUpdatePayment($order->id, ['request' => $data]);
-        $paypalOrderId = $data['paypalOrderId'];
-        $result        = $this->paypalClient->capturePaymentOrder($paypalOrderId);
-        OrderPaymentRepo::createOrUpdatePayment($order->id, ['response' => $result]);
-
-        try {
-            DB::beginTransaction();
-            if ($result['status'] === 'COMPLETED') {
-                StateMachineService::getInstance($order)->changeStatus(StateMachineService::PAID);
-                DB::commit();
-            }
-        } catch (\Exception $e) {
-            DB::rollBack();
-            dd($e);
+        if ($orderNumber === '') {
+            return response()->json(['message' => 'orderNumber is required'], 422);
         }
 
+        $customer      = current_customer();
+        $order         = OrderRepo::getOrderByNumber($orderNumber, $customer);
+        $paypalService = $this->initPaypal($order);
+
+        OrderPaymentRepo::createOrUpdatePayment($order->id, ['request' => $data]);
+
+        if ($paypalService->isNvpApi() || $this->hasNvpCaptureData($data, $request)) {
+            $token   = $this->getNvpToken($data, $request);
+            $payerId = $this->getNvpPayerId($data, $request);
+
+            if ($token === '' || $payerId === '') {
+                return response()->json(['message' => 'PayPal token and payer id are required'], 422);
+            }
+
+            $result = $paypalService->captureNvpPayment($token, $payerId);
+        } else {
+            $paypalOrderId = (string) ($data['paypalOrderId'] ?? $data['paypal_order_id'] ?? '');
+
+            if ($paypalOrderId === '') {
+                return response()->json(['message' => 'paypalOrderId is required'], 422);
+            }
+
+            if ($paypalService->paypalClient === null) {
+                return response()->json(['message' => 'PayPal REST client is not initialized'], 500);
+            }
+
+            $result = $paypalService->paypalClient->capturePaymentOrder($paypalOrderId);
+        }
+
+        OrderPaymentRepo::createOrUpdatePayment($order->id, ['response' => $result]);
+        $this->markOrderPaid($paypalService, $order, $result);
+
         return response()->json($result);
+    }
+
+    public function nvpReturn(Request $request): RedirectResponse
+    {
+        $data        = $request->all();
+        $orderNumber = $this->getOrderNumberFromData($data, $request);
+        $token       = $this->getNvpToken($data, $request);
+        $payerId     = $this->getNvpPayerId($data, $request);
+
+        if ($orderNumber === '' || $token === '' || $payerId === '') {
+            return $this->redirectWithMessage($request, $this->getFailureRedirectUrl($orderNumber), 'error', 'Paypal payment failed.');
+        }
+
+        try {
+            $customer      = current_customer();
+            $order         = OrderRepo::getOrderByNumber($orderNumber, $customer);
+            $paypalService = $this->initPaypal($order);
+
+            OrderPaymentRepo::createOrUpdatePayment($order->id, ['request' => $data]);
+            $result = $paypalService->captureNvpPayment($token, $payerId);
+            OrderPaymentRepo::createOrUpdatePayment($order->id, ['response' => $result]);
+            $this->markOrderPaid($paypalService, $order, $result);
+
+            $paid = $paypalService->isPaymentSuccessful($result);
+
+            return $this->redirectWithMessage(
+                $request,
+                $paid ? $this->getSuccessRedirectUrl($orderNumber) : $this->getFailureRedirectUrl($orderNumber),
+                $paid ? 'success' : 'error',
+                $paid ? 'Paypal payment completed.' : 'Paypal payment is not completed.'
+            );
+        } catch (\Throwable $e) {
+            return $this->redirectWithMessage($request, $this->getFailureRedirectUrl($orderNumber), 'error', 'Paypal payment failed.');
+        }
+    }
+
+    public function nvpCancel(Request $request): RedirectResponse
+    {
+        $data        = $request->all();
+        $orderNumber = $this->getOrderNumberFromData($data, $request);
+
+        return $this->redirectWithMessage($request, $this->getFailureRedirectUrl($orderNumber), 'error', 'Paypal payment was cancelled.');
+    }
+
+    public function nvpNotify(Request $request)
+    {
+        return response('OK');
+    }
+
+    private function markOrderPaid(PaypalService $paypalService, $order, array $result): void
+    {
+        DB::beginTransaction();
+
+        try {
+            if ($paypalService->isPaymentSuccessful($result)) {
+                StateMachineService::getInstance($order)->changeStatus(StateMachineService::PAID);
+            }
+
+            DB::commit();
+        } catch (\Exception $e) {
+            DB::rollBack();
+            throw $e;
+        }
+    }
+
+    private function getRequestData(Request $request): array
+    {
+        $data = \json_decode($request->getContent(), true);
+
+        return is_array($data) ? $data : $request->all();
+    }
+
+    private function getNvpCheckoutUrls(Request $request, string $orderNumber, array $data): array
+    {
+        return [
+            'return_url' => (string) ($data['returnUrl'] ?? $data['return_url'] ?? $this->getCallbackUrl('return', $orderNumber)),
+            'cancel_url' => (string) ($data['cancelUrl'] ?? $data['cancel_url'] ?? $this->getCallbackUrl('cancel', $orderNumber)),
+            'notify_url' => (string) ($data['notifyUrl'] ?? $data['notify_url'] ?? $this->getCallbackUrl('notify', $orderNumber)),
+        ];
+    }
+
+    private function getCallbackUrl(string $action, string $orderNumber): string
+    {
+        $routeName  = 'paypal.nvp.' . $action;
+        $parameters = ['orderNumber' => $orderNumber];
+
+        if (Route::has($routeName)) {
+            return route($routeName, $parameters);
+        }
+
+        return url('/paypal/nvp/' . $action) . '?' . http_build_query($parameters);
+    }
+
+    private function getOrderNumberFromData(array $data, Request $request): string
+    {
+        return trim((string) ($data['orderNumber'] ?? $data['order_number'] ?? $request->input('orderNumber') ?? $request->input('order_number') ?? ''));
+    }
+
+    private function hasNvpCaptureData(array $data, Request $request): bool
+    {
+        return $this->getNvpToken($data, $request) !== '' || $this->getNvpPayerId($data, $request) !== '';
+    }
+
+    private function getNvpToken(array $data, Request $request): string
+    {
+        return trim((string) ($data['token'] ?? $data['paypalToken'] ?? $request->input('token', '')));
+    }
+
+    private function getNvpPayerId(array $data, Request $request): string
+    {
+        return trim((string) ($data['PayerID'] ?? $data['payerId'] ?? $data['payer_id'] ?? $request->input('PayerID') ?? $request->input('payerId') ?? $request->input('payer_id') ?? ''));
+    }
+
+    private function getSuccessRedirectUrl(string $orderNumber): string
+    {
+        return $this->buildRedirectUrl('/checkout/success', $orderNumber);
+    }
+
+    private function getFailureRedirectUrl(string $orderNumber): string
+    {
+        return $this->buildRedirectUrl('/checkout/payment', $orderNumber);
+    }
+
+    private function buildRedirectUrl(string $path, string $orderNumber): string
+    {
+        $url = url($path);
+
+        if ($orderNumber !== '') {
+            $url .= '?' . http_build_query(['orderNumber' => $orderNumber]);
+        }
+
+        return $url;
+    }
+
+    private function redirectWithMessage(Request $request, string $url, string $key, string $message): RedirectResponse
+    {
+        $response = redirect($url);
+
+        if ($request->hasSession()) {
+            $response->with($key, $message);
+        }
+
+        return $response;
     }
 }

--- a/plugins/Paypal/Controllers/PaypalController.php
+++ b/plugins/Paypal/Controllers/PaypalController.php
@@ -22,7 +22,6 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Route;
 use Plugin\Paypal\Services\PaypalService;
 
 class PaypalController
@@ -200,14 +199,7 @@ class PaypalController
 
     private function getCallbackUrl(string $action, string $orderNumber): string
     {
-        $routeName  = 'paypal.nvp.' . $action;
-        $parameters = ['orderNumber' => $orderNumber];
-
-        if (Route::has($routeName)) {
-            return route($routeName, $parameters);
-        }
-
-        return url('/paypal/nvp/' . $action) . '?' . http_build_query($parameters);
+        return shop_route('paypal.nvp.' . $action, ['order_number' => $orderNumber]);
     }
 
     private function getOrderNumberFromData(array $data, Request $request): string
@@ -232,23 +224,16 @@ class PaypalController
 
     private function getSuccessRedirectUrl(string $orderNumber): string
     {
-        return $this->buildRedirectUrl('/checkout/success', $orderNumber);
+        return shop_route('checkout.success', ['order_number' => $orderNumber]);
     }
 
     private function getFailureRedirectUrl(string $orderNumber): string
     {
-        return $this->buildRedirectUrl('/checkout/payment', $orderNumber);
-    }
-
-    private function buildRedirectUrl(string $path, string $orderNumber): string
-    {
-        $url = url($path);
-
         if ($orderNumber !== '') {
-            $url .= '?' . http_build_query(['orderNumber' => $orderNumber]);
+            return shop_route('orders.pay', ['number' => $orderNumber]);
         }
 
-        return $url;
+        return shop_route('checkout.index');
     }
 
     private function redirectWithMessage(Request $request, string $url, string $key, string $message): RedirectResponse

--- a/plugins/Paypal/Lang/en/setting.php
+++ b/plugins/Paypal/Lang/en/setting.php
@@ -10,6 +10,17 @@
  */
 
 return [
-    'sandbox_mode' => 'Sandbox Mode',
-    'enabled'      => 'Enabled',
+    'api_mode'              => 'API Mode',
+    'api_mode_desc'         => 'REST keeps the existing PayPal integration. NVP/SOAP uses legacy Express Checkout API credentials.',
+    'api_mode_rest'         => 'REST API',
+    'api_mode_nvp'          => 'NVP/SOAP API',
+    'sandbox_mode'          => 'Sandbox Mode',
+    'enabled'               => 'Enabled',
+    'sandbox_api_username'  => 'Sandbox API Username',
+    'sandbox_api_password'  => 'Sandbox API Password',
+    'sandbox_api_signature' => 'Sandbox API Signature',
+    'live_api_username'     => 'Live API Username',
+    'live_api_password'     => 'Live API Password',
+    'live_api_signature'    => 'Live API Signature',
+    'nvp_credentials_desc'  => 'Required only when API Mode is NVP/SOAP.',
 ];

--- a/plugins/Paypal/Lang/zh_cn/setting.php
+++ b/plugins/Paypal/Lang/zh_cn/setting.php
@@ -10,6 +10,17 @@
  */
 
 return [
-    'sandbox_mode' => '沙盒模式',
-    'enabled'      => '开启',
+    'api_mode'              => 'API 模式',
+    'api_mode_desc'         => 'REST 保持现有 PayPal 集成不变；NVP/SOAP 使用旧版 Express Checkout API 凭证。',
+    'api_mode_rest'         => 'REST API',
+    'api_mode_nvp'          => 'NVP/SOAP API',
+    'sandbox_mode'          => '沙盒模式',
+    'enabled'               => '开启',
+    'sandbox_api_username'  => '沙盒 API 用户名',
+    'sandbox_api_password'  => '沙盒 API 密码',
+    'sandbox_api_signature' => '沙盒 API 签名',
+    'live_api_username'     => '正式 API 用户名',
+    'live_api_password'     => '正式 API 密码',
+    'live_api_signature'    => '正式 API 签名',
+    'nvp_credentials_desc'  => '仅在 API 模式选择 NVP/SOAP 时需要填写。',
 ];

--- a/plugins/Paypal/Routes/shop.php
+++ b/plugins/Paypal/Routes/shop.php
@@ -15,4 +15,7 @@ use Plugin\Paypal\Controllers\PaypalController;
 Route::group(['prefix' => 'paypal'], function () {
     Route::post('/create', [PaypalController::class, 'create']);
     Route::post('/capture', [PaypalController::class, 'capture']);
+    Route::match(['get', 'post'], '/nvp/return', [PaypalController::class, 'nvpReturn'])->name('paypal.nvp.return');
+    Route::match(['get', 'post'], '/nvp/cancel', [PaypalController::class, 'nvpCancel'])->name('paypal.nvp.cancel');
+    Route::post('/nvp/notify', [PaypalController::class, 'nvpNotify'])->name('paypal.nvp.notify');
 });

--- a/plugins/Paypal/Services/PaypalNvpClient.php
+++ b/plugins/Paypal/Services/PaypalNvpClient.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * PaypalNvpClient.php
+ *
+ * @copyright  2026 beikeshop.com - All Rights Reserved
+ * @link       https://beikeshop.com
+ */
+
+namespace Plugin\Paypal\Services;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Message\ResponseInterface;
+
+class PaypalNvpClient
+{
+    private const VERSION = '204.0';
+    private const SANDBOX_ENDPOINT = 'https://api-3t.sandbox.paypal.com/nvp';
+    private const LIVE_ENDPOINT = 'https://api-3t.paypal.com/nvp';
+    private const SANDBOX_CHECKOUT_URL = 'https://www.sandbox.paypal.com/cgi-bin/webscr';
+    private const LIVE_CHECKOUT_URL = 'https://www.paypal.com/cgi-bin/webscr';
+
+    private string $mode;
+    private string $username;
+    private string $password;
+    private string $signature;
+    private int $timeout;
+    private ClientInterface $httpClient;
+
+    public function __construct(array $config, ?ClientInterface $httpClient = null)
+    {
+        $this->mode       = ($config['mode'] ?? 'sandbox') === 'live' ? 'live' : 'sandbox';
+        $this->username   = trim((string) ($config['username'] ?? ''));
+        $this->password   = trim((string) ($config['password'] ?? ''));
+        $this->signature  = trim((string) ($config['signature'] ?? ''));
+        $this->timeout    = max(1, (int) ($config['timeout'] ?? 30));
+        $this->httpClient = $httpClient ?: new Client(['timeout' => $this->timeout]);
+    }
+
+    public function setExpressCheckout(array $parameters): array
+    {
+        $response = $this->request('SetExpressCheckout', $parameters);
+
+        if (empty($response['TOKEN'])) {
+            throw new \RuntimeException('PayPal NVP response did not include checkout token.');
+        }
+
+        $response['CHECKOUT_URL'] = $this->buildCheckoutUrl($response['TOKEN']);
+
+        return $response;
+    }
+
+    public function getExpressCheckoutDetails(string $token): array
+    {
+        return $this->request('GetExpressCheckoutDetails', [
+            'TOKEN' => $token,
+        ]);
+    }
+
+    public function doExpressCheckoutPayment(array $parameters): array
+    {
+        return $this->request('DoExpressCheckoutPayment', $parameters);
+    }
+
+    private function request(string $method, array $parameters): array
+    {
+        $this->assertConfigured();
+
+        $payload = array_merge([
+            'METHOD'    => $method,
+            'VERSION'   => self::VERSION,
+            'USER'      => $this->username,
+            'PWD'       => $this->password,
+            'SIGNATURE' => $this->signature,
+        ], $parameters);
+
+        try {
+            $response = $this->httpClient->request('POST', $this->endpoint(), [
+                'form_params' => $payload,
+                'timeout'     => $this->timeout,
+            ]);
+        } catch (GuzzleException $e) {
+            throw new \RuntimeException('PayPal NVP request failed: ' . $e->getMessage(), 0, $e);
+        }
+
+        $data = $this->parseResponse($response);
+        $this->assertSuccessfulResponse($data);
+
+        return $data;
+    }
+
+    private function parseResponse(ResponseInterface $response): array
+    {
+        parse_str((string) $response->getBody(), $data);
+
+        return array_change_key_case($data, CASE_UPPER);
+    }
+
+    private function assertConfigured(): void
+    {
+        if ($this->username === '' || $this->password === '' || $this->signature === '') {
+            throw new \RuntimeException('PayPal NVP API username, password, and signature are required.');
+        }
+    }
+
+    private function assertSuccessfulResponse(array $data): void
+    {
+        $ack = strtoupper((string) ($data['ACK'] ?? ''));
+
+        if (in_array($ack, ['SUCCESS', 'SUCCESSWITHWARNING'], true)) {
+            return;
+        }
+
+        $code    = (string) ($data['L_ERRORCODE0'] ?? '');
+        $short   = (string) ($data['L_SHORTMESSAGE0'] ?? '');
+        $message = (string) ($data['L_LONGMESSAGE0'] ?? $short ?: 'PayPal NVP request was not successful.');
+        $prefix  = $code !== '' ? "PayPal NVP error {$code}: " : 'PayPal NVP error: ';
+
+        throw new \RuntimeException($prefix . $message);
+    }
+
+    private function endpoint(): string
+    {
+        return $this->mode === 'live' ? self::LIVE_ENDPOINT : self::SANDBOX_ENDPOINT;
+    }
+
+    private function buildCheckoutUrl(string $token): string
+    {
+        $baseUrl = $this->mode === 'live' ? self::LIVE_CHECKOUT_URL : self::SANDBOX_CHECKOUT_URL;
+
+        return $baseUrl . '?' . http_build_query([
+            'cmd'   => '_express-checkout',
+            'token' => $token,
+        ]);
+    }
+}

--- a/plugins/Paypal/Services/PaypalService.php
+++ b/plugins/Paypal/Services/PaypalService.php
@@ -17,6 +17,7 @@ use Srmklive\PayPal\Services\PayPal;
 class PaypalService extends PaymentService
 {
     private const API_MODE_REST = 'rest';
+
     private const API_MODE_NVP = 'nvp';
 
     public ?PayPal $paypalClient = null;
@@ -49,11 +50,11 @@ class PaypalService extends PaymentService
             'mode'    => $mode,
             'sandbox' => [
                 'client_id'     => $paypalSetting['sandbox_client_id'] ?? '',
-                'client_secret' => $paypalSetting['sandbox_secret'] ?? '',
+                'client_secret' => $paypalSetting['sandbox_secret']    ?? '',
             ],
             'live' => [
                 'client_id'     => $paypalSetting['live_client_id'] ?? '',
-                'client_secret' => $paypalSetting['live_secret'] ?? '',
+                'client_secret' => $paypalSetting['live_secret']    ?? '',
             ],
             'payment_action' => 'Sale',
             'currency'       => system_setting('base.currency'),
@@ -85,8 +86,8 @@ class PaypalService extends PaymentService
                 'clientId'    => '',
                 'currency'    => $this->getOrderCurrency(),
                 'environment' => $mode,
-                'orderId'     => $paypalOrder['id'] ?? null,
-                'token'       => $paypalOrder['token'] ?? null,
+                'orderId'     => $paypalOrder['id']           ?? null,
+                'token'       => $paypalOrder['token']        ?? null,
                 'approvalUrl' => $paypalOrder['approval_url'] ?? null,
                 'userAction'  => 'paynow',
             ];
@@ -103,7 +104,7 @@ class PaypalService extends PaymentService
         return [
             'apiMode'     => self::API_MODE_REST,
             'clientId'    => $clientId,
-            'currency'    => $this->getRestCurrency(),
+            'currency'    => $this->getOrderCurrency(),
             'environment' => $mode,
             'orderId'     => $paypalOrder['id'],
             'userAction'  => 'paynow',  //'paynow/continue'
@@ -132,7 +133,7 @@ class PaypalService extends PaymentService
             'purchase_units' => [
                 [
                     'amount' => [
-                        'currency_code' => $this->getRestCurrency(),
+                        'currency_code' => $this->getOrderCurrency(),
                         'value'         => $total,
                     ],
                     'description' => $this->getOrderDescription(),
@@ -358,9 +359,11 @@ class PaypalService extends PaymentService
         return is_array($paypalSetting) ? $paypalSetting : [];
     }
 
-    private function getPaypalEnvironment(?array $paypalSetting = null): string
+    private function getPaypalEnvironment(array $paypalSetting = []): string
     {
-        $paypalSetting = $paypalSetting ?? $this->getPaypalSetting();
+        if ($paypalSetting === []) {
+            $paypalSetting = $this->getPaypalSetting();
+        }
 
         return ! empty($paypalSetting['sandbox_mode']) ? 'sandbox' : 'live';
     }
@@ -404,11 +407,6 @@ class PaypalService extends PaymentService
         }
 
         return url($path) . '?' . http_build_query($parameters);
-    }
-
-    private function getRestCurrency(): string
-    {
-        return strtoupper((string) system_setting('base.currency'));
     }
 
     private function getOrderCurrency(): string

--- a/plugins/Paypal/Services/PaypalService.php
+++ b/plugins/Paypal/Services/PaypalService.php
@@ -12,7 +12,6 @@
 namespace Plugin\Paypal\Services;
 
 use Beike\Shop\Services\PaymentService;
-use Illuminate\Support\Facades\Route;
 use Srmklive\PayPal\Services\PayPal;
 
 class PaypalService extends PaymentService
@@ -104,7 +103,7 @@ class PaypalService extends PaymentService
         return [
             'apiMode'     => self::API_MODE_REST,
             'clientId'    => $clientId,
-            'currency'    => $this->order->currency_code,
+            'currency'    => $this->getRestCurrency(),
             'environment' => $mode,
             'orderId'     => $paypalOrder['id'],
             'userAction'  => 'paynow',  //'paynow/continue'
@@ -133,7 +132,7 @@ class PaypalService extends PaymentService
             'purchase_units' => [
                 [
                     'amount' => [
-                        'currency_code' => $this->getOrderCurrency(),
+                        'currency_code' => $this->getRestCurrency(),
                         'value'         => $total,
                     ],
                     'description' => $this->getOrderDescription(),
@@ -394,13 +393,22 @@ class PaypalService extends PaymentService
 
     private function buildCallbackUrl(string $routeName, string $path, string $orderNumber): string
     {
-        $parameters = ['orderNumber' => $orderNumber];
+        $parameters = ['order_number' => $orderNumber];
 
-        if (Route::has($routeName)) {
-            return route($routeName, $parameters);
+        if (function_exists('shop_route')) {
+            return shop_route($routeName, $parameters);
+        }
+
+        if (app('router')->has('shop.' . $routeName)) {
+            return route('shop.' . $routeName, $parameters);
         }
 
         return url($path) . '?' . http_build_query($parameters);
+    }
+
+    private function getRestCurrency(): string
+    {
+        return strtoupper((string) system_setting('base.currency'));
     }
 
     private function getOrderCurrency(): string

--- a/plugins/Paypal/Services/PaypalService.php
+++ b/plugins/Paypal/Services/PaypalService.php
@@ -12,11 +12,17 @@
 namespace Plugin\Paypal\Services;
 
 use Beike\Shop\Services\PaymentService;
+use Illuminate\Support\Facades\Route;
 use Srmklive\PayPal\Services\PayPal;
 
 class PaypalService extends PaymentService
 {
-    public PayPal $paypalClient;
+    private const API_MODE_REST = 'rest';
+    private const API_MODE_NVP = 'nvp';
+
+    public ?PayPal $paypalClient = null;
+
+    private ?PaypalNvpClient $nvpClient = null;
 
     /**
      * @param             $order
@@ -26,7 +32,10 @@ class PaypalService extends PaymentService
     public function __construct($order)
     {
         parent::__construct($order);
-        $this->initPaypal();
+
+        if (! $this->isNvpApi()) {
+            $this->initPaypal();
+        }
     }
 
     /**
@@ -35,16 +44,17 @@ class PaypalService extends PaymentService
      */
     private function initPaypal(): void
     {
-        $paypalSetting = plugin_setting('paypal');
+        $paypalSetting = $this->getPaypalSetting();
+        $mode          = $this->getPaypalEnvironment($paypalSetting);
         $config        = [
-            'mode'    => $paypalSetting['sandbox_mode'] ? 'sandbox' : 'live',
+            'mode'    => $mode,
             'sandbox' => [
-                'client_id'     => $paypalSetting['sandbox_client_id'],
-                'client_secret' => $paypalSetting['sandbox_secret'],
+                'client_id'     => $paypalSetting['sandbox_client_id'] ?? '',
+                'client_secret' => $paypalSetting['sandbox_secret'] ?? '',
             ],
             'live' => [
-                'client_id'     => $paypalSetting['live_client_id'],
-                'client_secret' => $paypalSetting['live_secret'],
+                'client_id'     => $paypalSetting['live_client_id'] ?? '',
+                'client_secret' => $paypalSetting['live_secret'] ?? '',
             ],
             'payment_action' => 'Sale',
             'currency'       => system_setting('base.currency'),
@@ -65,18 +75,34 @@ class PaypalService extends PaymentService
      */
     public function getMobilePaymentData(): array
     {
-        $paypalSetting = plugin_setting('paypal');
-        $mode          = $paypalSetting['sandbox_mode'] ? 'sandbox' : 'live';
+        $paypalSetting = $this->getPaypalSetting();
+        $mode          = $this->getPaypalEnvironment($paypalSetting);
 
-        if ($mode == 'sandbox') {
-            $clientId = $paypalSetting['sandbox_client_id'];
+        if ($this->isNvpApi()) {
+            $paypalOrder = $this->createNvpOrder();
+
+            return [
+                'apiMode'     => self::API_MODE_NVP,
+                'clientId'    => '',
+                'currency'    => $this->getOrderCurrency(),
+                'environment' => $mode,
+                'orderId'     => $paypalOrder['id'] ?? null,
+                'token'       => $paypalOrder['token'] ?? null,
+                'approvalUrl' => $paypalOrder['approval_url'] ?? null,
+                'userAction'  => 'paynow',
+            ];
+        }
+
+        if ($mode === 'sandbox') {
+            $clientId = $paypalSetting['sandbox_client_id'] ?? '';
         } else {
-            $clientId = $paypalSetting['live_client_id'];
+            $clientId = $paypalSetting['live_client_id'] ?? '';
         }
 
         $paypalOrder = $this->createOrder();
 
         return [
+            'apiMode'     => self::API_MODE_REST,
             'clientId'    => $clientId,
             'currency'    => $this->order->currency_code,
             'environment' => $mode,
@@ -91,21 +117,344 @@ class PaypalService extends PaymentService
      */
     public function createOrder(): mixed
     {
-        $this->initPaypal();
+        if ($this->isNvpApi()) {
+            return $this->createNvpOrder();
+        }
+
+        if ($this->paypalClient === null) {
+            $this->initPaypal();
+        }
+
         $order = $this->order;
-        $total = round($order->total, 2);
+        $total = $this->formatAmount($order->total);
 
         return $this->paypalClient->createOrder([
             'intent'         => 'CAPTURE',
             'purchase_units' => [
                 [
                     'amount' => [
-                        'currency_code' => $order->currency_code,
+                        'currency_code' => $this->getOrderCurrency(),
                         'value'         => $total,
                     ],
-                    'description' => 'test',
+                    'description' => $this->getOrderDescription(),
                 ],
             ],
         ]);
+    }
+
+    public function createNvpOrder(array $urls = []): array
+    {
+        $orderNumber = $this->getOrderNumber();
+        $total       = $this->formatAmount($this->order->total);
+        $currency    = $this->getOrderCurrency();
+        $returnUrl   = $urls['return_url'] ?? $urls['returnUrl'] ?? $this->defaultNvpReturnUrl($orderNumber);
+        $cancelUrl   = $urls['cancel_url'] ?? $urls['cancelUrl'] ?? $this->defaultNvpCancelUrl($orderNumber);
+        $notifyUrl   = $urls['notify_url'] ?? $urls['notifyUrl'] ?? $this->defaultNvpNotifyUrl($orderNumber);
+
+        $parameters = [
+            'PAYMENTREQUEST_0_PAYMENTACTION' => 'Sale',
+            'PAYMENTREQUEST_0_AMT'           => $total,
+            'PAYMENTREQUEST_0_CURRENCYCODE'  => $currency,
+            'PAYMENTREQUEST_0_DESC'          => $this->getOrderDescription(),
+            'RETURNURL'                      => $returnUrl,
+            'CANCELURL'                      => $cancelUrl,
+            'NOSHIPPING'                     => '1',
+            'REQCONFIRMSHIPPING'             => '0',
+            'SOLUTIONTYPE'                   => 'Sole',
+            'LANDINGPAGE'                    => 'Billing',
+        ];
+
+        if ($orderNumber !== '') {
+            $parameters['PAYMENTREQUEST_0_INVNUM'] = $orderNumber;
+            $parameters['PAYMENTREQUEST_0_CUSTOM'] = $orderNumber;
+        }
+
+        if ($notifyUrl !== '') {
+            $parameters['PAYMENTREQUEST_0_NOTIFYURL'] = $notifyUrl;
+        }
+
+        $result      = $this->getNvpClient()->setExpressCheckout($parameters);
+        $token       = $result['TOKEN'];
+        $approvalUrl = $result['CHECKOUT_URL'];
+
+        return [
+            'id'           => $token,
+            'token'        => $token,
+            'status'       => strtoupper((string) ($result['ACK'] ?? '')),
+            'approval_url' => $approvalUrl,
+            'links'        => [
+                [
+                    'href'   => $approvalUrl,
+                    'rel'    => 'approve',
+                    'method' => 'GET',
+                ],
+            ],
+            'raw' => $result,
+        ];
+    }
+
+    public function captureNvpPayment(string $token, string $payerId): array
+    {
+        $token   = trim($token);
+        $payerId = trim($payerId);
+
+        if ($token === '' || $payerId === '') {
+            throw new \InvalidArgumentException('PayPal token and payer id are required.');
+        }
+
+        $details = $this->getNvpClient()->getExpressCheckoutDetails($token);
+        $this->validateNvpDetails($details);
+
+        if (! empty($details['PAYERID']) && (string) $details['PAYERID'] !== $payerId) {
+            throw new \RuntimeException('PayPal payer id does not match checkout details.');
+        }
+
+        $parameters = [
+            'TOKEN'                          => $token,
+            'PAYERID'                        => $payerId,
+            'PAYMENTREQUEST_0_PAYMENTACTION' => 'Sale',
+            'PAYMENTREQUEST_0_AMT'           => $this->formatAmount($this->order->total),
+            'PAYMENTREQUEST_0_CURRENCYCODE'  => $this->getOrderCurrency(),
+            'PAYMENTREQUEST_0_DESC'          => $this->getOrderDescription(),
+        ];
+
+        $orderNumber = $this->getOrderNumber();
+        if ($orderNumber !== '') {
+            $parameters['PAYMENTREQUEST_0_INVNUM'] = $orderNumber;
+        }
+
+        $response = $this->getNvpClient()->doExpressCheckoutPayment($parameters);
+
+        return [
+            'id'       => $response['PAYMENTINFO_0_TRANSACTIONID'] ?? null,
+            'status'   => $this->normalizeNvpPaymentStatus($response),
+            'token'    => $token,
+            'payer_id' => $payerId,
+            'details'  => $details,
+            'response' => $response,
+        ];
+    }
+
+    public function isPaymentSuccessful(array $result): bool
+    {
+        $status   = strtoupper((string) ($result['status'] ?? $result['PAYMENTINFO_0_PAYMENTSTATUS'] ?? ''));
+        $response = $result['response'] ?? [];
+
+        if ($status === '' && is_array($response)) {
+            $status = strtoupper((string) ($response['PAYMENTINFO_0_PAYMENTSTATUS'] ?? $response['PAYMENTSTATUS'] ?? ''));
+        }
+
+        return $status === 'COMPLETED';
+    }
+
+    public function isNvpApi(): bool
+    {
+        return $this->getApiMode() === self::API_MODE_NVP;
+    }
+
+    public function getApiMode(): string
+    {
+        $paypalSetting = $this->getPaypalSetting();
+        $mode          = strtolower(trim((string) $this->getSettingValue($paypalSetting, ['api_mode', 'api_standard', 'paypal_api_mode'], self::API_MODE_REST)));
+        $mode          = str_replace([' ', '-'], ['_', '_'], $mode);
+
+        return in_array($mode, ['nvp', 'soap', 'nvp_soap', 'nvp/soap'], true) ? self::API_MODE_NVP : self::API_MODE_REST;
+    }
+
+    private function getNvpClient(): PaypalNvpClient
+    {
+        if ($this->nvpClient instanceof PaypalNvpClient) {
+            return $this->nvpClient;
+        }
+
+        $paypalSetting = $this->getPaypalSetting();
+        $mode          = $this->getPaypalEnvironment($paypalSetting);
+        $credentials   = $this->getNvpCredentials($paypalSetting, $mode);
+        $timeout       = (int) $this->getSettingValue($paypalSetting, ['nvp_timeout', 'api_timeout'], 30);
+
+        return $this->nvpClient = new PaypalNvpClient([
+            'mode'      => $mode,
+            'username'  => $credentials['username'],
+            'password'  => $credentials['password'],
+            'signature' => $credentials['signature'],
+            'timeout'   => $timeout,
+        ]);
+    }
+
+    private function getNvpCredentials(array $paypalSetting, string $mode): array
+    {
+        $prefix = $mode === 'sandbox' ? 'sandbox' : 'live';
+
+        return [
+            'username' => (string) $this->getSettingValue($paypalSetting, [
+                'nvp_' . $prefix . '_username',
+                $prefix . '_nvp_username',
+                $prefix . '_api_username',
+                'api_' . $prefix . '_username',
+                $prefix . '_username',
+                'nvp_username',
+                'api_username',
+                'username',
+            ]),
+            'password' => (string) $this->getSettingValue($paypalSetting, [
+                'nvp_' . $prefix . '_password',
+                $prefix . '_nvp_password',
+                $prefix . '_api_password',
+                'api_' . $prefix . '_password',
+                $prefix . '_password',
+                'nvp_password',
+                'api_password',
+                'password',
+            ]),
+            'signature' => (string) $this->getSettingValue($paypalSetting, [
+                'nvp_' . $prefix . '_signature',
+                $prefix . '_nvp_signature',
+                $prefix . '_api_signature',
+                'api_' . $prefix . '_signature',
+                $prefix . '_signature',
+                'nvp_signature',
+                'api_signature',
+                'signature',
+            ]),
+        ];
+    }
+
+    private function normalizeNvpPaymentStatus(array $response): string
+    {
+        $status = strtoupper((string) ($response['PAYMENTINFO_0_PAYMENTSTATUS'] ?? $response['PAYMENTSTATUS'] ?? ''));
+
+        if ($status !== '') {
+            return $status;
+        }
+
+        return strtoupper((string) ($response['ACK'] ?? 'FAILED'));
+    }
+
+    private function validateNvpDetails(array $details): void
+    {
+        $amount = $details['PAYMENTREQUEST_0_AMT'] ?? $details['AMT'] ?? null;
+
+        if ($amount === null || $this->formatAmount($amount) !== $this->formatAmount($this->order->total)) {
+            throw new \RuntimeException('PayPal payment amount does not match the order amount.');
+        }
+
+        $currency = $details['PAYMENTREQUEST_0_CURRENCYCODE'] ?? $details['CURRENCYCODE'] ?? null;
+
+        if ($currency === null || strtoupper((string) $currency) !== $this->getOrderCurrency()) {
+            throw new \RuntimeException('PayPal payment currency does not match the order currency.');
+        }
+
+        $invoiceNumber = $details['PAYMENTREQUEST_0_INVNUM'] ?? $details['INVNUM'] ?? null;
+        $orderNumber   = $this->getOrderNumber();
+
+        if ($invoiceNumber !== null && $orderNumber !== '' && (string) $invoiceNumber !== $orderNumber) {
+            throw new \RuntimeException('PayPal invoice number does not match the order number.');
+        }
+    }
+
+    private function getPaypalSetting(): array
+    {
+        $paypalSetting = plugin_setting('paypal');
+
+        return is_array($paypalSetting) ? $paypalSetting : [];
+    }
+
+    private function getPaypalEnvironment(?array $paypalSetting = null): string
+    {
+        $paypalSetting = $paypalSetting ?? $this->getPaypalSetting();
+
+        return ! empty($paypalSetting['sandbox_mode']) ? 'sandbox' : 'live';
+    }
+
+    private function getSettingValue(array $settings, array $keys, $default = '')
+    {
+        foreach ($keys as $key) {
+            if (array_key_exists($key, $settings) && $settings[$key] !== null && $settings[$key] !== '') {
+                return $settings[$key];
+            }
+        }
+
+        return $default;
+    }
+
+    private function defaultNvpReturnUrl(string $orderNumber): string
+    {
+        return $this->buildCallbackUrl('paypal.nvp.return', '/paypal/nvp/return', $orderNumber);
+    }
+
+    private function defaultNvpCancelUrl(string $orderNumber): string
+    {
+        return $this->buildCallbackUrl('paypal.nvp.cancel', '/paypal/nvp/cancel', $orderNumber);
+    }
+
+    private function defaultNvpNotifyUrl(string $orderNumber): string
+    {
+        return $this->buildCallbackUrl('paypal.nvp.notify', '/paypal/nvp/notify', $orderNumber);
+    }
+
+    private function buildCallbackUrl(string $routeName, string $path, string $orderNumber): string
+    {
+        $parameters = ['orderNumber' => $orderNumber];
+
+        if (Route::has($routeName)) {
+            return route($routeName, $parameters);
+        }
+
+        return url($path) . '?' . http_build_query($parameters);
+    }
+
+    private function getOrderCurrency(): string
+    {
+        $currency = $this->order->currency_code ?? system_setting('base.currency');
+
+        return strtoupper((string) $currency);
+    }
+
+    private function formatAmount($amount): string
+    {
+        return number_format(round((float) $amount, 2), 2, '.', '');
+    }
+
+    private function getOrderDescription(): string
+    {
+        if (method_exists($this->order, 'getOrderDesc')) {
+            $description = (string) $this->order->getOrderDesc(127);
+        } else {
+            $description = 'Order ' . $this->getOrderNumber();
+        }
+
+        $description = trim($description);
+
+        if ($description === '') {
+            $description = 'Order ' . $this->getOrderNumber();
+        }
+
+        return $this->limitString($description, 127);
+    }
+
+    private function getOrderNumber(): string
+    {
+        foreach (['number', 'order_number', 'order_no'] as $key) {
+            $value = $this->order->{$key} ?? null;
+
+            if ($value !== null && $value !== '') {
+                return (string) $value;
+            }
+        }
+
+        if (($this->order->id ?? null) !== null) {
+            return (string) $this->order->id;
+        }
+
+        return '';
+    }
+
+    private function limitString(string $value, int $length): string
+    {
+        if (function_exists('mb_substr')) {
+            return mb_substr($value, 0, $length, 'UTF-8');
+        }
+
+        return substr($value, 0, $length);
     }
 }

--- a/plugins/Paypal/Views/checkout/payment.blade.php
+++ b/plugins/Paypal/Views/checkout/payment.blade.php
@@ -1,6 +1,34 @@
 <!-- Set up a container element for the button -->
 <div id="paypal-button-container" class="mt-4"></div>
 
+@if(($payment_setting['api_mode'] ?? 'rest') == 'nvp')
+<script>
+    const token = $('meta[name="csrf-token"]').attr('content')
+    fetch('/paypal/create', {
+        method: 'POST',
+        headers: {
+            'X-CSRF-Token': token
+        },
+        body: JSON.stringify({
+            orderNumber: "{{$order->number}}",
+        })
+    }).then(function (res) {
+        return res.json();
+    }).then(function (orderData) {
+        if (orderData.approval_url) {
+            location = orderData.approval_url;
+            return;
+        }
+
+        layer.alert(orderData.message || 'PayPal payment failed.', {
+            title: '{{ __('common.text_hint') }}',
+            closeBtn: 0,
+            area: ['400px', 'auto'],
+            btn: ['{{ __('common.confirm') }}']
+        });
+    });
+</script>
+@else
 <!-- Include the PayPal JavaScript SDK -->
 @if($payment_setting['sandbox_mode'])
     <script src="https://www.paypal.com/sdk/js?client-id={{ plugin_setting('paypal.sandbox_client_id') }}&currency={{ system_setting('base.currency') }}"></script>
@@ -67,3 +95,4 @@
         }
     }).render('#paypal-button-container');
 </script>
+@endif

--- a/plugins/Paypal/columns.php
+++ b/plugins/Paypal/columns.php
@@ -11,6 +11,18 @@
 
 return [
     [
+        'name'        => 'api_mode',
+        'label_key'   => 'setting.api_mode',
+        'type'        => 'select',
+        'value'       => 'rest',
+        'options'     => [
+            ['value' => 'rest', 'label_key' => 'setting.api_mode_rest'],
+            ['value' => 'nvp', 'label_key' => 'setting.api_mode_nvp'],
+        ],
+        'required'    => true,
+        'description_key' => 'setting.api_mode_desc',
+    ],
+    [
         'name'        => 'sandbox_client_id',
         'label'       => 'Sandbox Client ID',
         'type'        => 'string',
@@ -48,5 +60,47 @@ return [
         ],
         'required'    => true,
         'description' => '',
+    ],
+    [
+        'name'        => 'sandbox_api_username',
+        'label_key'   => 'setting.sandbox_api_username',
+        'type'        => 'string',
+        'required'    => false,
+        'description_key' => 'setting.nvp_credentials_desc',
+    ],
+    [
+        'name'        => 'sandbox_api_password',
+        'label_key'   => 'setting.sandbox_api_password',
+        'type'        => 'string',
+        'required'    => false,
+        'description_key' => 'setting.nvp_credentials_desc',
+    ],
+    [
+        'name'        => 'sandbox_api_signature',
+        'label_key'   => 'setting.sandbox_api_signature',
+        'type'        => 'string',
+        'required'    => false,
+        'description_key' => 'setting.nvp_credentials_desc',
+    ],
+    [
+        'name'        => 'live_api_username',
+        'label_key'   => 'setting.live_api_username',
+        'type'        => 'string',
+        'required'    => false,
+        'description_key' => 'setting.nvp_credentials_desc',
+    ],
+    [
+        'name'        => 'live_api_password',
+        'label_key'   => 'setting.live_api_password',
+        'type'        => 'string',
+        'required'    => false,
+        'description_key' => 'setting.nvp_credentials_desc',
+    ],
+    [
+        'name'        => 'live_api_signature',
+        'label_key'   => 'setting.live_api_signature',
+        'type'        => 'string',
+        'required'    => false,
+        'description_key' => 'setting.nvp_credentials_desc',
     ],
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,7 +2,6 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
-use Plugin\Paypal\Controllers\PaypalController;
 
 /*
 |--------------------------------------------------------------------------
@@ -18,7 +17,3 @@ use Plugin\Paypal\Controllers\PaypalController;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
-
-Route::match(['get', 'post'], '/paypal/nvp/return', [PaypalController::class, 'nvpReturn'])->name('paypal.nvp.return');
-Route::match(['get', 'post'], '/paypal/nvp/cancel', [PaypalController::class, 'nvpCancel'])->name('paypal.nvp.cancel');
-Route::post('/paypal/nvp/notify', [PaypalController::class, 'nvpNotify'])->name('paypal.nvp.notify');

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
+use Plugin\Paypal\Controllers\PaypalController;
 
 /*
 |--------------------------------------------------------------------------
@@ -17,3 +18,7 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::match(['get', 'post'], '/paypal/nvp/return', [PaypalController::class, 'nvpReturn'])->name('paypal.nvp.return');
+Route::match(['get', 'post'], '/paypal/nvp/cancel', [PaypalController::class, 'nvpCancel'])->name('paypal.nvp.cancel');
+Route::post('/paypal/nvp/notify', [PaypalController::class, 'nvpNotify'])->name('paypal.nvp.notify');

--- a/tests/Unit/PaypalNvpClientTest.php
+++ b/tests/Unit/PaypalNvpClientTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Unit;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Plugin\Paypal\Services\PaypalNvpClient;
+
+class PaypalNvpClientTest extends TestCase
+{
+    public function test_set_express_checkout_parses_success_response_and_builds_checkout_url(): void
+    {
+        $history = [];
+        $client  = $this->makeHttpClient(
+            [new Response(200, [], 'ACK=Success&TOKEN=EC-123456')],
+            $history
+        );
+
+        $nvpClient = new PaypalNvpClient($this->config(), $client);
+        $result    = $nvpClient->setExpressCheckout([
+            'PAYMENTREQUEST_0_AMT'          => '12.30',
+            'PAYMENTREQUEST_0_CURRENCYCODE' => 'USD',
+        ]);
+
+        $this->assertSame('Success', $result['ACK']);
+        $this->assertSame('EC-123456', $result['TOKEN']);
+        $this->assertSame(
+            'https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_express-checkout&token=EC-123456',
+            $result['CHECKOUT_URL']
+        );
+        $this->assertSame('https://api-3t.sandbox.paypal.com/nvp', (string) $history[0]['request']->getUri());
+        $this->assertStringContainsString('METHOD=SetExpressCheckout', (string) $history[0]['request']->getBody());
+        $this->assertStringContainsString('USER=api-user', (string) $history[0]['request']->getBody());
+    }
+
+    public function test_paypal_error_response_throws_normalized_exception(): void
+    {
+        $history = [];
+        $client  = $this->makeHttpClient(
+            [new Response(200, [], 'ACK=Failure&L_ERRORCODE0=10002&L_LONGMESSAGE0=Authentication+failed')],
+            $history
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('PayPal NVP error 10002: Authentication failed');
+
+        (new PaypalNvpClient($this->config(), $client))->getExpressCheckoutDetails('EC-123456');
+    }
+
+    public function test_missing_credentials_fail_before_request(): void
+    {
+        $history = [];
+        $client  = $this->makeHttpClient([new Response(200, [], 'ACK=Success')], $history);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('PayPal NVP API username, password, and signature are required.');
+
+        try {
+            (new PaypalNvpClient($this->config(['username' => '']), $client))->getExpressCheckoutDetails('EC-123456');
+        } finally {
+            $this->assertCount(0, $history);
+        }
+    }
+
+    private function makeHttpClient(array $responses, array &$history): Client
+    {
+        $mock  = new MockHandler($responses);
+        $stack = HandlerStack::create($mock);
+        $stack->push(Middleware::history($history));
+
+        return new Client(['handler' => $stack]);
+    }
+
+    private function config(array $overrides = []): array
+    {
+        return array_merge([
+            'mode'      => 'sandbox',
+            'username'  => 'api-user',
+            'password'  => 'api-password',
+            'signature' => 'api-signature',
+            'timeout'   => 5,
+        ], $overrides);
+    }
+}

--- a/tests/Unit/PaypalServiceTest.php
+++ b/tests/Unit/PaypalServiceTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Unit;
+
+use Plugin\Paypal\Services\PaypalService;
+use Tests\TestCase;
+
+class PaypalServiceTest extends TestCase
+{
+    public function test_rest_order_creation_keeps_order_currency(): void
+    {
+        config(['bk.system.base.currency' => 'USD']);
+
+        if (! class_exists('Srmklive\\PayPal\\Services\\PayPal', false)) {
+            class_alias(PaypalClientSpy::class, 'Srmklive\\PayPal\\Services\\PayPal');
+        }
+
+        $paypalClient = new PaypalClientSpy();
+        $service      = new class((object) ['currency_code' => 'EUR', 'number' => 'ORDER-1001', 'status' => 'unpaid', 'total' => 42.35], $paypalClient) extends PaypalService
+        {
+            public function __construct(object $order, PaypalClientSpy $paypalClient)
+            {
+                $this->order        = $order;
+                $this->paypalClient = $paypalClient;
+            }
+
+            public function isNvpApi(): bool
+            {
+                return false;
+            }
+        };
+
+        $service->createOrder();
+
+        $this->assertSame(
+            'EUR',
+            $paypalClient->lastOrder['purchase_units'][0]['amount']['currency_code']
+        );
+    }
+}
+
+class PaypalClientSpy
+{
+    public array $lastOrder = [];
+
+    public function createOrder(array $order): array
+    {
+        $this->lastOrder = $order;
+
+        return ['id' => 'REST-ORDER-1'];
+    }
+}


### PR DESCRIPTION
## Summary
- Add PayPal NVP/SOAP API mode alongside the existing REST integration.
- Add NVP Express Checkout client, callback routes, admin credential fields, and checkout handling.
- Preserve the existing REST PayPal currency behavior so REST orders continue using the order currency instead of the shop base currency.

## Context
This replaces the closed PR #129 and includes the compatibility fix requested in review. The NVP/SOAP order currency handling is scoped to NVP mode, while REST mode keeps the previous order-currency behavior.

## Tests
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' vendor/bin/phpunit tests/Unit/PaypalServiceTest.php --filter test_rest_order_creation_keeps_order_currency`
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' vendor/bin/phpunit tests/Unit/PaypalNvpClientTest.php`
- `php -l plugins/Paypal/Services/PaypalService.php && php -l tests/Unit/PaypalServiceTest.php && php -l tests/Unit/PaypalNvpClientTest.php`